### PR TITLE
Add task service interface with mock

### DIFF
--- a/packages/fe/src/services/task/http_task_client.ts
+++ b/packages/fe/src/services/task/http_task_client.ts
@@ -1,0 +1,19 @@
+import type {
+        AddTaskReq,
+        AddTaskRes,
+} from "multivlibe-model/tasks/add_task";
+import type {
+        ListTasksReq,
+        ListTasksRes,
+} from "multivlibe-model/tasks/list_tasks";
+import type { TaskService } from "./task_service";
+
+export class HttpTaskClient implements TaskService {
+        async listTasks(_req: ListTasksReq): Promise<ListTasksRes> {
+                throw new Error("not implemented");
+        }
+
+        async addTask(_req: AddTaskReq): Promise<AddTaskRes> {
+                throw new Error("not implemented");
+        }
+}

--- a/packages/fe/src/services/task/mock_task_client.ts
+++ b/packages/fe/src/services/task/mock_task_client.ts
@@ -1,0 +1,66 @@
+import type {
+        AddTaskReq,
+        AddTaskRes,
+} from "multivlibe-model/tasks/add_task";
+import type {
+        ListTasksReq,
+        ListTasksRes,
+} from "multivlibe-model/tasks/list_tasks";
+import type { Task } from "multivlibe-model/tasks/task";
+import { delay } from "multivlibe-model/utils/delay";
+import type { TaskService } from "./task_service";
+
+/** In-memory mock implementation of TaskService used for development. */
+const DEFAULT_DATE = new Date("2023-01-01T00:00:00Z").valueOf();
+
+export class MockTaskClient implements TaskService {
+        private tasks: Task[] = [
+                {
+                        id: 1,
+                        instanceId: 1,
+                        runner: "DryRun",
+                        title: "Initial task",
+                        created: DEFAULT_DATE,
+                        updated: DEFAULT_DATE,
+                },
+        ];
+        private nextId = 2;
+
+        constructor(private readonly timeout: number = 1000) {}
+
+        async listTasks(req: ListTasksReq): Promise<ListTasksRes> {
+                await delay(this.timeout);
+
+                const ids = req.instanceIds;
+                const result =
+                        !ids || ids.length === 0
+                                ? this.tasks
+                                : this.tasks.filter((t) => ids.includes(t.instanceId));
+
+                return {
+                        code: "ok",
+                        tasks: result,
+                };
+        }
+
+        async addTask(req: AddTaskReq): Promise<AddTaskRes> {
+                await delay(this.timeout);
+
+                try {
+                        const now = Date.now();
+                        const task: Task = {
+                                id: this.nextId,
+                                created: now,
+                                updated: now,
+                                ...req,
+                        };
+                        this.tasks.push(task);
+                        this.nextId++;
+
+                        return { code: "ok", task };
+                } catch (err) {
+                        console.error(err);
+                        return { code: "unknown_error" };
+                }
+        }
+}

--- a/packages/fe/src/services/task/task_service.ts
+++ b/packages/fe/src/services/task/task_service.ts
@@ -1,0 +1,27 @@
+import type {
+        AddTaskReq,
+        AddTaskRes,
+} from "multivlibe-model/tasks/add_task";
+import type {
+        ListTasksReq,
+        ListTasksRes,
+} from "multivlibe-model/tasks/list_tasks";
+
+/** Service responsible for managing tasks attached to repository instances. */
+export interface TaskService {
+        /**
+         * Retrieve tasks for the specified instances.
+         *
+         * @param req - optional instance IDs to filter by
+         * @returns a response containing the matching tasks or an error code
+         */
+        listTasks: (req: ListTasksReq) => Promise<ListTasksRes>;
+
+        /**
+         * Create a new task for the given instance.
+         *
+         * @param req - instance ID, runner and title
+         * @returns the created task or a failure response
+         */
+        addTask: (req: AddTaskReq) => Promise<AddTaskRes>;
+}

--- a/packages/model/src/tasks/add_task.ts
+++ b/packages/model/src/tasks/add_task.ts
@@ -1,0 +1,29 @@
+import { z } from "zod/v4";
+import { TaskSchema } from "./task";
+
+/** Request payload for creating a new task */
+export const AddTaskReqSchema = z.object({
+        instanceId: z.number(),
+        runner: z.literal("DryRun"),
+        title: z.string(),
+});
+export type AddTaskReq = z.infer<typeof AddTaskReqSchema>;
+
+/** Successful response when task is created */
+export const AddTaskSuccessResSchema = z.object({
+        code: z.literal("ok"),
+        task: TaskSchema,
+});
+/** Generic failure response */
+export const AddTaskFailureResSchema = z.object({
+        code: z.literal("unknown_error"),
+});
+/** Union type for success or failure responses */
+export const AddTaskResSchema = z.union([
+        AddTaskSuccessResSchema,
+        AddTaskFailureResSchema,
+]);
+
+export type AddTaskSuccessRes = z.infer<typeof AddTaskSuccessResSchema>;
+export type AddTaskFailureRes = z.infer<typeof AddTaskFailureResSchema>;
+export type AddTaskRes = z.infer<typeof AddTaskResSchema>;

--- a/packages/model/src/tasks/list_tasks.ts
+++ b/packages/model/src/tasks/list_tasks.ts
@@ -1,0 +1,28 @@
+import { z } from "zod/v4";
+import { TaskSchema } from "./task";
+
+/** Request for listing tasks */
+export const ListTasksReqSchema = z.object({
+        /** Optional list of instance IDs to filter tasks */
+        instanceIds: z.array(z.number()).optional(),
+});
+export type ListTasksReq = z.infer<typeof ListTasksReqSchema>;
+
+/** Successful response including all tasks */
+export const ListTasksSuccessResSchema = z.object({
+        code: z.literal("ok"),
+        tasks: z.array(TaskSchema),
+});
+/** Generic failure response */
+export const ListTasksFailureResSchema = z.object({
+        code: z.literal("unknown_error"),
+});
+/** Union type of possible list tasks responses */
+export const ListTasksResSchema = z.union([
+        ListTasksSuccessResSchema,
+        ListTasksFailureResSchema,
+]);
+
+export type ListTasksSuccessRes = z.infer<typeof ListTasksSuccessResSchema>;
+export type ListTasksFailureRes = z.infer<typeof ListTasksFailureResSchema>;
+export type ListTasksRes = z.infer<typeof ListTasksResSchema>;

--- a/packages/model/src/tasks/task.ts
+++ b/packages/model/src/tasks/task.ts
@@ -1,0 +1,19 @@
+import { z } from "zod/v4";
+
+/** Schema describing a task that runs on a repository instance. */
+export const TaskSchema = z.object({
+        /** Auto-incremented identifier */
+        id: z.number(),
+        /** Instance this task is attached to */
+        instanceId: z.number(),
+        /** Runner implementation executing this task */
+        runner: z.literal("DryRun"),
+        /** Title provided by the runner describing the task */
+        title: z.string(),
+        /** Creation timestamp */
+        created: z.int(),
+        /** Last update timestamp */
+        updated: z.int(),
+});
+
+export type Task = z.infer<typeof TaskSchema>;


### PR DESCRIPTION
## Summary
- model: add `Task` schema and API schemas for adding and listing tasks
- frontend: add `TaskService` interface
- frontend: provide `MockTaskClient` for in-memory testing
- frontend: stub out `HttpTaskClient`

## Testing
- `npx -y biome check .` *(fails: npm registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857b2a412548325b4a791ed724ddb9e